### PR TITLE
refactor(observation builder): use reset instead of additional set_env.

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -67,7 +67,9 @@ jobs:
         run: |
           python -m pip install -r requirements-dev.txt
           export BENCHMARK_EPISODES_FOLDER=$PWD/episodes
-          export PYTHONPATH=$PWD 
+          export PYTHONPATH=$PWD
+          # DEPENDENCY SWITCH: picked up by docker-compose.yml's FLATLAND_RL_PIP_URL build arg.
+          export FLATLAND_RL_PIP_URL="git+https://github.com/flatland-association/flatland-rl.git@${{ env.flatland-rl-ref }}"
           pytest -s flatland_baselines/deadlock_avoidance_heuristic/tests
 
   test-online-offline-evaluation-demo:
@@ -120,6 +122,8 @@ jobs:
         run: |
           python -m pip install -r requirements-dev.txt
           export PYTHONPATH=$PWD
+          # DEPENDENCY SWITCH: picked up by docker-compose.yml's FLATLAND_RL_PIP_URL build arg.
+          export FLATLAND_RL_PIP_URL="git+https://github.com/flatland-association/flatland-rl.git@${{ env.flatland-rl-ref }}"
           pytest -s flatland_baselines/deadlock_avoidance_heuristic/online_demo/
       - name: Run tests for offline evaluation
         run: |

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -2,7 +2,7 @@ name: Checks
 
 env:
   # DEPENDENCY SWITCH:
-  flatland-rl-ref: v4.2.6
+  flatland-rl-ref: 437-drop-set-env-hack-in-obs-builder-interface
 
 on:
   workflow_dispatch:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -2,7 +2,7 @@ name: Checks
 
 env:
   # DEPENDENCY SWITCH:
-  flatland-rl-ref: 437-drop-set-env-hack-in-obs-builder-interface
+  flatland-rl-ref: main
 
 on:
   workflow_dispatch:

--- a/flatland_baselines/deadlock_avoidance_heuristic/Dockerfile
+++ b/flatland_baselines/deadlock_avoidance_heuristic/Dockerfile
@@ -2,8 +2,16 @@
 ARG FLATLAND_RL_REF=latest-py3.12
 FROM ghcr.io/flatland-association/flatland-rl:${FLATLAND_RL_REF}
 
+# DEPENDENCY SWITCH: pip install flatland-rl from a git+https URL (e.g.
+# git+https://github.com/flatland-association/flatland-rl.git@some-branch), overriding whatever version the
+# base image above has baked in. Leave empty (default) to keep the base image's own flatland-rl. A plain
+# GitHub tarball URL does not work here: flatland-rl uses setuptools_scm, which needs real git metadata
+# (stripped from tarball downloads) to infer a version.
+ARG FLATLAND_RL_PIP_URL=""
+
 COPY ./ ./
 RUN pip install -e .
+RUN if [ -n "$FLATLAND_RL_PIP_URL" ]; then pip install --force-reinstall --no-deps "$FLATLAND_RL_PIP_URL"; fi
 
 ENV POLICY=flatland_baselines.deadlock_avoidance_heuristic.policy.deadlock_avoidance_policy.DeadLockAvoidancePolicy
 ENV OBS_BUILDER=flatland_baselines.deadlock_avoidance_heuristic.observation.full_env_observation.FullEnvObservation

--- a/flatland_baselines/deadlock_avoidance_heuristic/observation/full_env_observation.py
+++ b/flatland_baselines/deadlock_avoidance_heuristic/observation/full_env_observation.py
@@ -13,8 +13,5 @@ class FullEnvObservation(ObservationBuilder[RailEnv, RailEnv]):
     def get(self, handle: AgentHandle = 0) -> ObservationType:
         return self.env
 
-    def reset(self):
-        pass
-
-    def set_env(self, env):
+    def reset(self, env):
         self.env = env

--- a/flatland_baselines/deadlock_avoidance_heuristic/online_demo/docker-compose.yml
+++ b/flatland_baselines/deadlock_avoidance_heuristic/online_demo/docker-compose.yml
@@ -103,6 +103,9 @@ services:
     build:
       context: evaluator
       dockerfile: Dockerfile
+      args:
+        # DEPENDENCY SWITCH:
+        FLATLAND_RL_PIP_URL: ${FLATLAND_RL_PIP_URL:-}
     depends_on:
       redis:
         condition: service_healthy
@@ -130,6 +133,9 @@ services:
     build:
       context: ../../..
       dockerfile: flatland_baselines/deadlock_avoidance_heuristic/online_demo/submission/Dockerfile
+      args:
+        # DEPENDENCY SWITCH:
+        FLATLAND_RL_PIP_URL: ${FLATLAND_RL_PIP_URL:-}
     depends_on:
       redis:
         condition: service_healthy

--- a/flatland_baselines/deadlock_avoidance_heuristic/online_demo/evaluator/Dockerfile
+++ b/flatland_baselines/deadlock_avoidance_heuristic/online_demo/evaluator/Dockerfile
@@ -2,6 +2,14 @@
 ARG TAG=latest-py3.12
 FROM ghcr.io/flatland-association/flatland-rl:${TAG}
 
+# DEPENDENCY SWITCH: pip install flatland-rl from a git+https URL (e.g.
+# git+https://github.com/flatland-association/flatland-rl.git@some-branch), overriding whatever version the
+# base image above has baked in. Leave empty (default) to keep the base image's own flatland-rl. A plain
+# GitHub tarball URL does not work here: flatland-rl uses setuptools_scm, which needs real git metadata
+# (stripped from tarball downloads) to infer a version.
+ARG FLATLAND_RL_PIP_URL=""
+RUN if [ -n "$FLATLAND_RL_PIP_URL" ]; then pip install --force-reinstall --no-deps "$FLATLAND_RL_PIP_URL"; fi
+
 COPY run.sh ./
 COPY evaluator.py ./
 

--- a/flatland_baselines/deadlock_avoidance_heuristic/online_demo/submission/Dockerfile
+++ b/flatland_baselines/deadlock_avoidance_heuristic/online_demo/submission/Dockerfile
@@ -2,6 +2,14 @@
 ARG TAG=latest-py3.12
 FROM ghcr.io/flatland-association/flatland-rl:${TAG}
 
+# DEPENDENCY SWITCH: pip install flatland-rl from a git+https URL (e.g.
+# git+https://github.com/flatland-association/flatland-rl.git@some-branch), overriding whatever version the
+# base image above has baked in. Leave empty (default) to keep the base image's own flatland-rl. A plain
+# GitHub tarball URL does not work here: flatland-rl uses setuptools_scm, which needs real git metadata
+# (stripped from tarball downloads) to infer a version.
+ARG FLATLAND_RL_PIP_URL=""
+RUN if [ -n "$FLATLAND_RL_PIP_URL" ]; then pip install --force-reinstall --no-deps "$FLATLAND_RL_PIP_URL"; fi
+
 RUN mkdir -p flatland_baselines/deadlock_avoidance_heuristic
 COPY flatland_baselines/deadlock_avoidance_heuristic/online_demo/submission/run.sh ./
 COPY flatland_baselines/deadlock_avoidance_heuristic/ ./flatland_baselines/deadlock_avoidance_heuristic

--- a/flatland_baselines/deadlock_avoidance_heuristic/online_demo/test_online.py
+++ b/flatland_baselines/deadlock_avoidance_heuristic/online_demo/test_online.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import time
 from pathlib import Path
+from subprocess import CalledProcessError
 
 import pandas as pd
 import pytest
@@ -11,6 +12,7 @@ from testcontainers.compose import DockerCompose
 
 from flatland_baselines.deadlock_avoidance_heuristic.offline_demo.test_offline import verify_online_offline_calibration_envs_v2, \
     verify_online_offline_calibration_envs_v3_trunc
+from flatland_baselines.deadlock_avoidance_heuristic.utils.docker_compose_helpers import _dump_compose_logs, _print_output
 
 logger = logging.getLogger(__name__)
 
@@ -76,15 +78,14 @@ def _containers_fixture(environments, seed, baselines_ref, rl_ref) -> Path:
             basic.stop()
             duration = time.time() - start_time
             logger.info(f"\\ end docker down. Took {duration:.2f} seconds.")
+        except CalledProcessError as e:
+            print(f"Failure: {e}")
+            _print_output(e.stdout.decode(errors="ignore"), e.stderr.decode(errors="ignore"))
+            _dump_compose_logs(basic)
+            raise e
         except BaseException as e:
-            print("An exception occurred during running docker compose:")
-            print(e)
-            stdout, stderr = basic.get_logs()
-            print("-- An exception occurred during running docker compose stdo:")
-            print(stdout)
-            print("-- An exception occurred during running docker compose stderr:")
-            print(stderr)
-            print("-- An exception occurred during running docker compose reraise.")
+            print(f"An exception occurred during running docker compose: {e}")
+            _dump_compose_logs(basic)
             raise e
     finally:
         shutil.rmtree(newpath, ignore_errors=True)

--- a/flatland_baselines/deadlock_avoidance_heuristic/tests/docker-compose.yml
+++ b/flatland_baselines/deadlock_avoidance_heuristic/tests/docker-compose.yml
@@ -45,6 +45,9 @@ services:
     build:
       context: ../../..
       dockerfile: flatland_baselines/deadlock_avoidance_heuristic/Dockerfile
+      args:
+        # DEPENDENCY SWITCH:
+        FLATLAND_RL_PIP_URL: ${FLATLAND_RL_PIP_URL:-}
     depends_on:
       setup:
         condition: service_completed_successfully

--- a/flatland_baselines/deadlock_avoidance_heuristic/tests/test_regression_deadlock_avoidancy.py
+++ b/flatland_baselines/deadlock_avoidance_heuristic/tests/test_regression_deadlock_avoidancy.py
@@ -4,11 +4,13 @@ import shutil
 import tempfile
 import time
 from pathlib import Path
+from subprocess import CalledProcessError
 
 import pytest
 from testcontainers.compose import DockerCompose
 
 from flatland.evaluators.trajectory_analysis import data_frame_for_trajectories, persist_data_frame_for_trajectories
+from flatland_baselines.deadlock_avoidance_heuristic.utils.docker_compose_helpers import _dump_compose_logs, _print_output
 
 logger = logging.getLogger(__name__)
 
@@ -63,12 +65,14 @@ def _containers_fixture(environments) -> Path:
             basic.stop()
             duration = time.time() - start_time
             logger.info(f"\\ end docker down. Took {duration:.2f} seconds.")
+        except CalledProcessError as e:
+            print(f"Failure: {e}")
+            _print_output(e.stdout.decode(errors="ignore"), e.stderr.decode(errors="ignore"))
+            _dump_compose_logs(basic)
+            raise e
         except BaseException as e:
-            print("An exception occurred during running docker compose:")
-            print(e)
-            stdout, stderr = basic.get_logs()
-            print(stdout)
-            print(stderr)
+            print(f"An exception occurred during running docker compose: {e}")
+            _dump_compose_logs(basic)
             raise e
     finally:
         shutil.rmtree(newpath, ignore_errors=True)

--- a/flatland_baselines/deadlock_avoidance_heuristic/utils/docker_compose_helpers.py
+++ b/flatland_baselines/deadlock_avoidance_heuristic/utils/docker_compose_helpers.py
@@ -1,0 +1,14 @@
+from testcontainers.compose import DockerCompose
+
+
+def _print_output(stdout: str, stderr: str) -> None:
+    print(f"stdout: {stdout}")
+    print(f"stderr: {stderr}")
+
+
+def _dump_compose_logs(basic: DockerCompose) -> None:
+    try:
+        stdout, stderr = basic.get_logs()
+        _print_output(stdout, stderr)
+    except Exception as e:
+        print(f"Could not get logs from docker compose: {e}")


### PR DESCRIPTION
## Changes

<!-- Describe the changes you made. -->
- refactor(observation builder): use reset instead of additional set_env.
- chore: update deps temporarily.
- ci(dla): improve logging.
- build: optionally inject flatland-rl-ref from gh workflow into docker compose.

## Related issues

Required by https://github.com/flatland-association/flatland-rl/pull/478

<!--
Link to every issue from the issue tracker (if any) you addressed in this PR.
See [here](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) on how to use keywords to automatically close the issue when someone merges the pull request
-->

## Request for Comment

* Risk: <!-- [low/mid/high] -->
* Discussion: <!-- [low/mid/high] -->

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Prefix the PR title with one of the labels of [Keep a Changelog](https://keepachangelog.com/).
<!--
  - `[Added]`  for new features.
  - `[Changed]` for changes in existing functionality.
  - `[Deprecated]` for soon-to-be removed features.
  - `[Removed]` for now removed features.
  - `[Fixed]` for any bug fixes.
  - `[Security]` in case of vulnerabilities. 
-->
- [ ] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
