### PR TITLE
ci: update gh actions. Node.js 20 is deprecated.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,11 +33,11 @@ jobs:
           echo "TAG=${{ github.event.inputs.tag || github.head_ref || 'latest' }}" | tr '/' '-' >> $GITHUB_ENV
       - uses: actions/checkout@v6
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -63,7 +63,7 @@ jobs:
           df -h
           docker system df
       - name: Build and Push Generic Container Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -74,7 +74,7 @@ jobs:
           tags: |
             ghcr.io/${{ steps.convert2lowercase.outputs.REPO_TAG_LOWERCASE }}:${{ env.TAG }}
       - name: Build and Push Random Policy Container Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: flatland_baselines/random/Dockerfile
@@ -85,7 +85,7 @@ jobs:
           tags: |
             ghcr.io/${{ steps.convert2lowercase.outputs.REPO_TAG_LOWERCASE }}-random:${{ env.TAG }}
       - name: Build and Push DLA Container Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: flatland_baselines/deadlock_avoidance_heuristic/Dockerfile
@@ -96,7 +96,7 @@ jobs:
           tags: |
             ghcr.io/${{ steps.convert2lowercase.outputs.REPO_TAG_LOWERCASE }}-deadlock-avoidance-heuristic:${{ env.TAG }}
       - name: Build and Push DLA-intermediate Container Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: flatland_baselines/deadlock_avoidance_heuristic/Dockerfile_intermediate
@@ -107,7 +107,7 @@ jobs:
           tags: |
             ghcr.io/${{ steps.convert2lowercase.outputs.REPO_TAG_LOWERCASE }}-deadlock-avoidance-heuristic-intermediate:${{ env.TAG }}
       - name: Build and Push Forward-Only Heuristic Container Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: flatland_baselines/forward_only_heuristic/Dockerfile
@@ -118,7 +118,7 @@ jobs:
           tags: |
             ghcr.io/${{ steps.convert2lowercase.outputs.REPO_TAG_LOWERCASE }}-forward-only-heuristic:${{ env.TAG }}
       - name: Build and Push Forever Heuristic Container Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: flatland_baselines/forever_heuristic/Dockerfile
@@ -129,7 +129,7 @@ jobs:
           tags: |
             ghcr.io/${{ steps.convert2lowercase.outputs.REPO_TAG_LOWERCASE }}-forever-heuristic:${{ env.TAG }}
       - name: Build and Push Do Nothing Heuristic Container Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: flatland_baselines/do_nothing_heuristic/Dockerfile


### PR DESCRIPTION

## Changes

ci: update gh actions. Node.js 20 is deprecated. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/.


## Related issues

<!--
Link to every issue from the issue tracker (if any) you addressed in this PR.
See [here](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) on how to use keywords to automatically close the issue when someone merges the pull request
-->

## Request for Comment

* Risk: <!-- [low/mid/high] -->
* Discussion: <!-- [low/mid/high] -->

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Prefix the PR title with one of the labels of [Keep a Changelog](https://keepachangelog.com/).
<!--
  - `[Added]`  for new features.
  - `[Changed]` for changes in existing functionality.
  - `[Deprecated]` for soon-to-be removed features.
  - `[Removed]` for now removed features.
  - `[Fixed]` for any bug fixes.
  - `[Security]` in case of vulnerabilities. 
-->
- [ ] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
